### PR TITLE
IE11 fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,7 @@
   "description": "Transition reflow in response to vue data changes.",
   "scripts": {
     "build": "webpack",
-    "prepublish": "npm run build",
-    "postinstall": "npm run build"
+    "prepublish": "npm run build"
   },
   "repository": {
     "type": "git",
@@ -21,7 +20,7 @@
     "webpack": "^4.10.1",
     "webpack-cli": "^2.1.4"
   },
-  "module": "src/index.js",
+  "module": "dist/vue-smooth-reflow.min.js",
   "main": "dist/vue-smooth-reflow.min.js",
   "unpkg": "dist/vue-smooth-reflow.min.js",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Transition reflow in response to vue data changes.",
   "scripts": {
     "build": "webpack",
-    "prepublish": "npm run build"
+    "prepublish": "npm run build",
+    "postinstall": "npm run build"
   },
   "repository": {
     "type": "git",

--- a/src/index.js
+++ b/src/index.js
@@ -10,14 +10,14 @@
 
 const mixin = {
     methods: {
-        $smoothReflow(options) {
+        $smoothReflow: function(options) {
             let _registerElement = registerElement.bind(this)
             if (Array.isArray(options))
                 options.forEach(_registerElement)
             else
                 _registerElement(options)
         },
-        $unsmoothReflow(options) {
+        $unsmoothReflow: function(options) {
             let _unregisterElement = unregisterElement.bind(this)
             if (Array.isArray(options))
                 options.forEach(_unregisterElement)
@@ -25,7 +25,7 @@ const mixin = {
                 _unregisterElement(options)
         },
     },
-    beforeMount() {
+    beforeMount: function() {
         this._smoothElements = []
 
         this._endListener = event => {
@@ -34,13 +34,13 @@ const mixin = {
             }
         }
     },
-    mounted() {
+    mounted: function() {
         this.$el.addEventListener('transitionend', this._endListener, { passive: true })
     },
-    destroyed() {
+    destroyed: function() {
         this.$el.removeEventListener('transitionend', this._endListener, { passive: true })
     },
-    beforeUpdate() {
+    beforeUpdate: function() {
         // The component $el can be null during mounted, if it's hidden by a falsy v-if
         // Duplicate event listeners are ignored, so it's safe to add this listener multiple times.
         this.$el.addEventListener('transitionend', this._endListener, { passive: true })
@@ -53,7 +53,7 @@ const mixin = {
             smoothEl.setBeforeValues()
         }
     },
-    updated() {
+    updated: function() {
         this.$nextTick(() => {
             // Retrieve component element on demand
             // It could have been hidden by v-if/v-show

--- a/src/index.js
+++ b/src/index.js
@@ -10,14 +10,14 @@
 
 const mixin = {
     methods: {
-        $smoothReflow: function(options) {
+        $smoothReflow(options) {
             let _registerElement = registerElement.bind(this)
             if (Array.isArray(options))
                 options.forEach(_registerElement)
             else
                 _registerElement(options)
         },
-        $unsmoothReflow: function(options) {
+        $unsmoothReflow(options) {
             let _unregisterElement = unregisterElement.bind(this)
             if (Array.isArray(options))
                 options.forEach(_unregisterElement)
@@ -25,7 +25,7 @@ const mixin = {
                 _unregisterElement(options)
         },
     },
-    beforeMount: function() {
+    beforeMount() {
         this._smoothElements = []
 
         this._endListener = event => {
@@ -34,13 +34,13 @@ const mixin = {
             }
         }
     },
-    mounted: function() {
+    mounted() {
         this.$el.addEventListener('transitionend', this._endListener, { passive: true })
     },
-    destroyed: function() {
+    destroyed() {
         this.$el.removeEventListener('transitionend', this._endListener, { passive: true })
     },
-    beforeUpdate: function() {
+    beforeUpdate() {
         // The component $el can be null during mounted, if it's hidden by a falsy v-if
         // Duplicate event listeners are ignored, so it's safe to add this listener multiple times.
         this.$el.addEventListener('transitionend', this._endListener, { passive: true })
@@ -53,7 +53,7 @@ const mixin = {
             smoothEl.setBeforeValues()
         }
     },
-    updated: function() {
+    updated() {
         this.$nextTick(() => {
             // Retrieve component element on demand
             // It could have been hidden by v-if/v-show

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -21,7 +21,7 @@ const config = {
                 use: {
                     loader: 'babel-loader',
                     options: {
-                        presets: [['@babel/preset-env'. {
+                        presets: [['@babel/preset-env', {
                             targets: {
                                 browsers: ['last 2 versions', 'safari >= 9', '> 1%', 'IE 11']       
                             }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -26,6 +26,7 @@ const config = {
                                 browsers: ['last 2 versions', 'safari >= 9', '> 1%', 'IE 11']       
                             }
                         }]],
+                        plugins: ["transform-class-properties", "transform-es2015-arrow-functions"],
                         babelrc: false
                     }
                 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -21,7 +21,11 @@ const config = {
                 use: {
                     loader: 'babel-loader',
                     options: {
-                        presets: ['@babel/preset-env'],
+                        presets: [['@babel/preset-env'. {
+                            targets: {
+                                browsers: ['last 2 versions', 'safari >= 9', '> 1%', 'IE 11']       
+                            }
+                        }]],
                         babelrc: false
                     }
                 }


### PR DESCRIPTION
vue-smooth-reflow does not work in IE11. This fork, and PR, aim to resolve that. 

The only changes herein are to config files - no code has been altered. The two changes are as follows: 

1. babel config updated to include some specific options for `babel-preset-env`, and to add a couple of important plugins for IE compatibility

2. `module` set to the compiled script in `package.json` as bundlers were seemingly looking to the src file even when the compiled file was available. In circumstances where third party modules don't get processed (they are simply bundled in the project I am working on) this causes change number 1 to be ignored

I have tested these changes as best I can, by copying the project into my larger project and compiling it manually there, and it appears to resolve issues with IE as far as I can tell. You will likely want to test this yourself before accepting this PR.